### PR TITLE
Use build args for Dockerfiles

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -366,11 +366,11 @@ Map getMatrixTasks(image, config) {
     return getTasks(axes, image, config, include, exclude)
 }
 
-def buildImage(img, filename, config) {
+def buildImage(img, filename, arch, distro, config) {
     if(filename == "") {
         config.logger.fatal("No docker filename specified, skipping build docker")
     }
-    customImage = docker.build("${img}", "-f ${filename} . ")
+    customImage = docker.build("${img}", "-f ${filename} --build-arg ARCH=${arch} --build-arg DISTRO=${distro} . ")
     customImage.push()
 }
 
@@ -433,7 +433,7 @@ def buildDocker(image, config) {
             }
             if (need_build) {
                 config.logger.info("Building - ${img} - ${filename}")
-                buildImage(img, filename, config)
+                buildImage(img, filename, arch, distro, config)
             }
         }
     }

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -407,7 +407,9 @@ def buildDocker(image, config) {
 
     def img = image.url
     def arch = image.arch
-    def filename = image.filename.toString()
+    // Vasily Ryabov: we need .toString() to make changed_files.contains(filename) work correctly
+    // See https://stackoverflow.com/q/56829842/3648361
+    def filename = image.filename.toString().trim()
     def distro = image.name
     def changed_files = config.get("cFiles")
 
@@ -428,7 +430,7 @@ def buildDocker(image, config) {
                 config.logger.info("Forcing building file per user request: ${filename} ... ")
                 need_build++
             }
-            config.logger.debug("Dockerfile name: '${filename}'")
+            config.logger.debug("Dockerfile name: ${filename}")
             config.logger.debug("Changed files: ${changed_files}")
             if (changed_files.contains(filename)) {
                 config.logger.info("Forcing building, file modified by commit: ${filename} ... ")

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -409,6 +409,7 @@ def buildDocker(image, config) {
     def arch     = image.arch
     def filename = image.filename
     def distro   = image.name
+    def changed_files = config.get("cFiles")
 
     stage("Prepare docker image for ${config.job}/$arch/$distro") {
         config.logger.info("Going to fetch docker image: ${img} from ${config.registry_host}")
@@ -427,7 +428,9 @@ def buildDocker(image, config) {
                 config.logger.info("Forcing building file per user request: ${filename} ... ")
                 need_build++
             }
-            if (config.get("cFiles").contains(filename)) {
+            config.logger.debug("filename: ${filename}")
+            config.logger.debug("Changed files: ${changed_files}")
+            if (changed_files.contains(filename)) {
                 config.logger.info("Forcing building, file modified by commit: ${filename} ... ")
                 need_build++
             }

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -405,10 +405,10 @@ String getChangedFilesList(config) {
 
 def buildDocker(image, config) {
 
-    def img      = image.url
-    def arch     = image.arch
+    def img = image.url
+    def arch = image.arch
     def filename = image.filename
-    def distro   = image.name
+    def distro = image.name
     def changed_files = config.get("cFiles")
 
     stage("Prepare docker image for ${config.job}/$arch/$distro") {
@@ -428,7 +428,7 @@ def buildDocker(image, config) {
                 config.logger.info("Forcing building file per user request: ${filename} ... ")
                 need_build++
             }
-            config.logger.debug("filename: ${filename}")
+            config.logger.debug("Dockerfile name: '${filename}'")
             config.logger.debug("Changed files: ${changed_files}")
             if (changed_files.contains(filename)) {
                 config.logger.info("Forcing building, file modified by commit: ${filename} ... ")

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -407,7 +407,7 @@ def buildDocker(image, config) {
 
     def img = image.url
     def arch = image.arch
-    def filename = image.filename
+    def filename = image.filename.toString()
     def distro = image.name
     def changed_files = config.get("cFiles")
 


### PR DESCRIPTION
Many our internal Dockerfile's contain "ARG" statements at the beginning of Dockerfile. When we need "docker build", these ARGs are required. The error looks so:
```
+ docker build -t <censored> -f <Dockerfile> .
Sending build context to Docker daemon  9.502MB

Step 1/8 : ARG ARCH
Step 2/8 : ARG DISTRO
Step 3/8 : FROM <censored>
invalid reference format
```

@artemry-mlnx FYI

I think we need better solution in a mid-term so that ARGs are passed more explicitly and transparently. This is just a hotfix.