### PR TITLE
Сatch errors to allow finishing other containers

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -254,7 +254,9 @@ def runK8(image, branchName, config, axis) {
         node(POD_LABEL) {
             stage (branchName) {
                 container(cname) {
-                    runSteps(image, config)
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                        runSteps(image, config)
+                    }
                 }
             }
         }
@@ -463,7 +465,9 @@ def build_docker_on_k8(image, config) {
             onUnstash()
 
             container('docker') {
-                buildDocker(image, config)
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    buildDocker(image, config)
+                }
             }
         }
     }


### PR DESCRIPTION
Other containers were killed right after the first failure without this check. Now we can finish build on CentOS while Ubuntu build is failing. Tested on internal project.