### PR TITLE
Make path to Docker image on harbor more configurable

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -88,11 +88,23 @@ def gen_image_map(config) {
             if (!dfile.build_args) {
                 dfile.build_args = ""
             }
+            if (!dfile.uri) {
+                // default URI subpath for Docker image on a harbor
+                dfile.uri = "${arch}/${name}"
+            }
+
+            def env_map = env.getEnvironment()
+            dfile.each { key, value ->
+                env_map[key] = value
+            }
+            GroovyShell env_shell = new GroovyShell(new Binding(env_map))
+            dfile.uri = env_shell.evaluate('"' + dfile.uri +'"')
+
             def item = [\
                 arch: "${arch}", \
                 tag:  "${dfile.tag}", \
                 filename: "${dfile.file}", \
-                url: "${config.registry_host}${config.registry_path}/${arch}/${dfile.name}:${dfile.tag}", \
+                url: "${config.registry_host}${config.registry_path}/${dfile.uri}:${dfile.tag}", \
                 name: "${dfile.name}", \
                 build_args: "${dfile.build_args}" \
             ]

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -153,8 +153,7 @@ def gen_image_map(config) {
             dfile.each { key, value ->
                 env_map[key] = value
             }
-            GroovyShell env_shell = new GroovyShell(new Binding(env_map))
-            dfile.uri = env_shell.evaluate('"' + dfile.uri +'"')
+            dfile.uri = resolveTemplate(env_map, dfile.uri)
 
             def item = [\
                 arch: "${arch}", \


### PR DESCRIPTION
Example:
```
runs_on_dockers:
  - {arch: 'x86_64', name: 'ubuntu16.04', uri: '$arch/$name/mofed-$MOFED_VERSION', tag: 'latest'}
```
Default value for URI is `'$arch/$name'`.