### PR TITLE
attach junit results

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ steps:
     always: env > always_env.txt
 # define artifacts to collect for specific step
     archiveArtifacts: 'step_failed.log,always_env.txt'
+# define raw xml results to collect for specific step
+    archiveJunit: 'test-results.xml'
 
 # executed once, before job starts its steps
 pipeline_start:
@@ -331,6 +333,9 @@ pipeline_on_image_build:
 
 # List of artifacts to attach to Jenkins results page for build
 archiveArtifacts: config.log
+
+# List of raw xml results to attach to Jenkins results page for build
+archiveJunit: 'myproject/target/test-reports/*.xml'
 
 # Fail job is one of the steps fails or continue
 failFast: false

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -107,6 +107,7 @@ def run_step_shell(cmd, title, oneStep, config) {
         }
 
         attachArtifacts(config, oneStep.archiveArtifacts)
+        attachJunit(config, oneStep.archiveJunit)
 
         if (ret.rc != 0) {
             def msg = "Step ${title} failed with exit code=${ret.rc}"
@@ -279,6 +280,17 @@ def attachArtifacts(config, args) {
         }
     }
 }
+
+def attachJunit(config, args) {
+    if (args != null) {
+        try {
+            junit(testResults: args, allowEmptyResults: true)
+        } catch (e) {
+            config.logger.warn("Failed to add junit results: " + args + " reason: " + e)
+        }
+    }
+}
+
 
 @NonCPS
 int getDebugLevel() {
@@ -461,6 +473,7 @@ def runSteps(image, config, branchName, axis) {
         run_step(image, config, one.name, oneStep, axis)
     }
     attachArtifacts(config, config.archiveArtifacts)
+    attachJunit(config, config.archiveJunit)
 }
 
 def getConfigVal(config, list, defaultVal=null, toString=true) {


### PR DESCRIPTION
Add option to attach junit results to Jenkins build.

Signed-off-by: Andrii Holovchenko <andriih@nvidia.com>