### PR TITLE
Use limits/requests at "docker build" stage as well

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -710,8 +710,8 @@ def runK8(image, branchName, config, axis, steps=config.steps) {
     def runAsUser = image.runAsUser ?: getConfigVal(config, ['kubernetes', 'runAsUser'], "0")
     def runAsGroup = image.runAsGroup ?: getConfigVal(config, ['kubernetes', 'runAsGroup'], "0")
     def privileged = image.privileged ?: getConfigVal(config, ['kubernetes', 'privileged'], false)
-    def limits = image.limits ?: getConfigVal(config, ['kubernetes', 'limits'], "")
-    def requests = image.requests ?: getConfigVal(config, ['kubernetes', 'requests'], "")
+    def limits = image.limits ?: getConfigVal(config, ['kubernetes', 'limits'], "{memory: 16Gi, cpu: 16000m}")
+    def requests = image.requests ?: getConfigVal(config, ['kubernetes', 'requests'], "{memory: 16Gi, cpu: 16000m}")
     def annotations = image.annotations ?: getConfigVal(config, ['kubernetes', 'annotations'], [], false)
     def caps_add = image.caps_add ?: getConfigVal(config, ['kubernetes', 'caps_add'], "[]")
     def yaml = """
@@ -1147,11 +1147,22 @@ def build_docker_on_k8(image, config) {
 
     def hostNetwork = image.hostNetwork ?: getConfigVal(config, ['kubernetes', 'hostNetwork'], false)
     def privileged = image.privileged ?: getConfigVal(config, ['kubernetes', 'privileged'], false)
-
+    def limits = image.limits ?: getConfigVal(config, ['kubernetes', 'limits'], "{memory: 16Gi, cpu: 16000m}")
+    def requests = image.requests ?: getConfigVal(config, ['kubernetes', 'requests'], "{memory: 16Gi, cpu: 16000m}")
+    def yaml = """
+spec:
+  containers:
+    - name: docker
+      resources:
+        limits: ${limits}
+        requests: ${requests}
+"""
     podTemplate(
         cloud: cloudName,
         nodeSelector: nodeSelector,
         hostNetwork: hostNetwork,
+        yamlMergeStrategy: merge(),
+        yaml: yaml,
         containers: [
             containerTemplate(name: 'jnlp', image: k8sArchConf.jnlpImage, args: '${computer.jnlpmac} ${computer.name}'),
             containerTemplate(privileged: privileged, name: 'docker', image: k8sArchConf.dockerImage, ttyEnabled: true, alwaysPullImage: true, command: 'cat')


### PR DESCRIPTION
Also make default limits to eliminate OOM for docker engine on overloaded host. Tested stability with Rivermax and CollectX.