### PR TITLE
Disable cache for manually forced "docker build"

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1069,6 +1069,7 @@ def buildImage(config, image) {
     if ("${env.build_dockers}" == "true") {
         config.logger.info("Forcing building file per user request: ${filename} ... ")
         need_build++
+        extra_args += ' --no-cache'
     }
     config.logger.debug("Changed files: ${changed_files}")
     if (changed_files.contains(filename)) {


### PR DESCRIPTION
Tested on one project with build_dockers==true. Better docker cache management could be implemented later, after we have correct DinD (Docker-in-Docker) implementation.