### PR TITLE
Set nice pod name to identify OS better

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -723,6 +723,7 @@ def runK8(image, branchName, config, axis, steps=config.steps) {
     def listV = parseListV(config.volumes)
     listV.addAll(parseListNfsV(config.nfs_volumes))
     def cname = image.get("name").replaceAll("[\\.:/_]", "")
+    def pod_name = config.job + "-" + cname + "-" + env.BUILD_NUMBER
 
     def k8sArchConf = getArchConf(config, axis.arch)
     def nodeSelector = ''
@@ -773,6 +774,7 @@ spec:
         yamlMergeStrategy: merge(),
         serviceAccount: service_account,
         namespace: namespace,
+        name: pod_name,
         yaml: yaml,
         containers: [
             containerTemplate(name: 'jnlp', image: k8sArchConf.jnlpImage, args: '${computer.jnlpmac} ${computer.name}'),
@@ -1163,6 +1165,8 @@ def build_docker_on_k8(image, config) {
 
     def listV = parseListV(config.volumes)
     listV.addAll(parseListNfsV(config.nfs_volumes))
+    def cname = image.get("name").replaceAll("[\\.:/_]", "")
+    def pod_name = config.job + "-build-" + cname + "-" + env.BUILD_NUMBER
 
     def cloudName = image.cloud ?: getConfigVal(config, ['kubernetes', 'cloud'], null)
     if (!cloudName) {
@@ -1207,6 +1211,7 @@ spec:
         cloud: cloudName,
         nodeSelector: nodeSelector,
         hostNetwork: hostNetwork,
+        name: pod_name,
         yamlMergeStrategy: merge(),
         yaml: yaml,
         containers: [


### PR DESCRIPTION
Tested on one project. The list of pods looks more interesting:
```
rivermax-ci-demo-build-centos77-531-ljjk5-wlkt8           2/2     Running             0          84s
rivermax-ci-demo-build-centos79-531-jgf8j-r0nmh           2/2     Running             0          84s
rivermax-ci-demo-build-centos81-531-msbks-bmm24           2/2     Running             0          84s
rivermax-ci-demo-build-oracle84-531-bpnbb-m6kjh           0/2     ContainerCreating   0          84s
rivermax-ci-demo-build-rhel78-531-xc5n7-ptwsf             2/2     Running             0          84s
rivermax-ci-demo-build-rhel79-531-sgxf9-gfr72             2/2     Running             0          84s
rivermax-ci-demo-build-rhel81-531-l1x4v-q0hs0             2/2     Running             0          84s
rivermax-ci-demo-build-rhel83-531-t6hng-kvxjt             2/2     Running             0          84s
rivermax-ci-demo-build-ubuntu1804-531-tfrc9-p75nl         2/2     Running             0          84s
```