### PR TITLE
add check for usernamePassword format

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -626,11 +626,12 @@ def run_step(image, config, title, oneStep, axis, runtime=null) {
                         }
                     } else {
                         // usernamePassword by default
-                        if (found.usernameVariable && found.passwordVariable) {
-                            credentials.add(usernamePassword(credentialsId: found.credentialsId,
-                                            passwordVariable: found.passwordVariable,
-                                            usernameVariable: found.usernameVariable))
+                        if (!found.usernameVariable || !found.passwordVariable) {
+                            reportFail(title, "credentialsId '${found.credentialsId}' has unsupported format (${found})!")
                         }
+                        credentials.add(usernamePassword(credentialsId: found.credentialsId,
+                                        passwordVariable: found.passwordVariable,
+                                        usernameVariable: found.usernameVariable))
                     }
                 }
                 withCredentials(credentials) {


### PR DESCRIPTION
If credentials type was not specified then
we assume that type is usernamePassword, but
we don't check if it has a proper format.