### PR TITLE
Add registry_auth check

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1211,7 +1211,7 @@ def buildDocker(image, config) {
     vars += toEnvVars(config, config.env)
 
     withEnv(vars) {
-        if (config.registry_host && image.url.contains(config.registry_host)) {
+        if (config.registry_host && config.registry_auth && image.url.contains(config.registry_host)) {
             docker.withRegistry("https://${config.registry_host}", config.registry_auth) {
                 buildImage(config, image)
             }


### PR DESCRIPTION
There is no reason to log into a registry if credentials are not provided (withRegistry allows this with a null variable). Conversely, it fixes an issue where REGISTRY_AUTH_FILE is defined and subsequently overridden by the docker (podman) login command.