### PR TITLE
Fix spread not yet supported error

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1212,12 +1212,14 @@ def buildDocker(image, config) {
 
     withEnv(vars) {
         if (config.registry_host && image.url.contains(config.registry_host)) {
-            def opts = ["https://${config.registry_host}"]
             if (config.registry_auth) {
-                opts.add(config.registry_auth)
-            }
-            docker.withRegistry(*opts) {
-                buildImage(config, image)
+                docker.withRegistry("https://${config.registry_host}", config.registry_auth) { 
+                    buildImage(config, image) 
+                }
+            } else {
+                docker.withRegistry("https://${config.registry_host}") {  
+                    buildImage(config, image) 
+                }
             }
         } else {
             buildImage(config, image)


### PR DESCRIPTION
Groovy spread operators support was added
in workflow-cps-plugin >= 3536.vb_8a_6628079d5, so don't use it for bacward compatibility.
(More info: https://issues.jenkins.io/browse/JENKINS-46163)