### PR TITLE
Add Pod level K8S_NODE_NAME variable to manifest

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -837,6 +837,11 @@ def runK8(image, branchName, config, axis, steps=config.steps) {
 spec:
   containers:
     - name: ${cname}
+      env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       resources:
         limits: ${limits}
         requests: ${requests}
@@ -1296,6 +1301,11 @@ def build_docker_on_k8(image, config) {
 spec:
   containers:
     - name: docker
+      env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       resources:
         limits: ${limits}
         requests: ${requests}


### PR DESCRIPTION
We often need to define which node the Pod is running on quickly. The most convenient way is to reflect K8S_NODE_NAME in the job branch/container environment and job logs