### PR TITLE
[ngci] update ngci version

### DIFF
--- a/vars/ngci.groovy
+++ b/vars/ngci.groovy
@@ -3,10 +3,10 @@
 int call(ctx, oneStep, config) {
     def args = oneStep.args
 
-    library(identifier: 'ngci@5.0',
+    library(identifier: 'ngci@5.0.4-26',
             retriever: modernSCM([$class: 'GitSCMSource',
             remote: 'ssh://git-nbu.nvidia.com:12023/DevOps/Jenkins/ci_framework',
-            credentialsId: 'b7d08ca7-378c-45d6-ac4b-3f30bdf49168' ]))
+            credentialsId: 'swx-jenkins_ssh_key' ]))
 
     if (args.size() < 1) {
         ctx.reportFail(oneStep.name, 'fatal: DynamicAction() expects at least 1 parameter')


### PR DESCRIPTION
Today we are using NGCI tag 5.0, which uses images from harbor This causes issues when running on our DR site in PUNA, since it doesnt support geoDNS.

A fix for this was provided under tag 5.0.4-26, which we should move to Also with security compliance we are required to give unique and meaningful names to our credentials stored in jenkins, instead of cred ID generated by jenkins.

Change ngci version from 5.0 to 5.0.4-26
Change credentialsId from auto generated ID to swx-jenkins_ssh_key (exact copy)