### PR TITLE
Update .ci/Makefile to use GeoDNS URL for docker registry (harbor)

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -11,7 +11,7 @@ TOPDIR := $(shell git rev-parse --show-toplevel)
 
 PROJ     := $(shell basename `cd .. && pwd | tr [A-Z] [a-z]`)
 
-REPO_URL := harbor.mellanox.com/swx-storage/${PROJ}
+REPO_URL := nbu-harbor.gtm.nvidia.com/swx-storage/${PROJ}
 REGISTRY := ${REPO_URL}/${ARCH}
 
 TAG    := $(shell git log -1 --pretty=%h)


### PR DESCRIPTION
We're still using "https://harbor.mellanox.com/" for docker login command
We need to switch to GeoDNS URLs to be able to keep using ci-demo @ DR site