### PR TITLE
Remove 2nd clone when pulling from scm

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1402,6 +1402,8 @@ def startPipeline(String label) {
                 logger.debug("SKIP_2ND_GIT_CHECKOUT was set , skipping checkout.")
                 env.GIT_COMMIT      = sh(script: 'git rev-parse --short HEAD || true', returnStdout: true)
                 env.GIT_PREV_COMMIT = sh(script: 'git rev-parse --short HEAD~ || true', returnStdout: true)
+                def debug_bi = sh(script: 'pwd;git rev-parse --is-inside-work-tree ||:; echo "WORKSPACE=${WORKSPACE}"; ls -la ${WORKSPACE};ls -la ${WORKSPACE}@tmp/; ', returnStdout: true)
+                logger.debug("BI:${debug_bi}")
             } else {
                 forceCleanupWS()
                 def scmVars = checkout scm

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1395,12 +1395,14 @@ def startPipeline(String label) {
         logger = new Logger(this)
 
         stage("Checkout source code") {
-            if ( isEnvVarSet(env.SKIP_2ND_GIT_CHECKOUT) ){
+            // check we are in a git directory and that env.SKIP_2ND_GIT_CHECKOUT is set and skip ci-demo clone
+            def gitRc = sh(script: 'git rev-parse --git-dir &>/dev/null', returnStatus: true)
+            if ( isEnvVarSet(env.SKIP_2ND_GIT_CHECKOUT) && gitRc == 0 ){
                 // get GIT_COMMIT and GIT_PREV_COMMIT from git commands in case 2nd git clone was skipped
                 logger.debug("SKIP_2ND_GIT_CHECKOUT was set , skipping checkout.")
-                env.GIT_COMMIT      = sh(script: 'git rev-parse --short HEAD', returnStdout: true)
-                env.GIT_PREV_COMMIT = sh(script: 'git rev-parse --short HEAD~', returnStdout: true)
-            }else{
+                env.GIT_COMMIT      = sh(script: 'git rev-parse --short HEAD || true', returnStdout: true)
+                env.GIT_PREV_COMMIT = sh(script: 'git rev-parse --short HEAD~ || true', returnStdout: true)
+            } else {
                 forceCleanupWS()
                 def scmVars = checkout scm
                 env.GIT_COMMIT      = scmVars.GIT_COMMIT


### PR DESCRIPTION
Adding an option to skip the workspace cleanup and additional git clone (cehckout scm call).
When a job runs from SCM the jenkins job will clone the repo, adding a checkout scm from within the ci-demo will result in additional same clone.

In heavy repos (where clone can take a lot of time ) this change can reduce the job time by a factor (e.g. tested it with a repo that takes 8 minutes to clone it reduces run time of the job from 40 minutes to ~31 which is significant.

This change is triggered by adding SKIP_2ND_GIT_CLONE env variable on the job (if it is set then the clone section is skipped) if SKIP_2ND_GIT_CLONE  is not present than the second clone will work as it is (for backward compatibility in case some jobs are not running from SCM initially)