### PR TITLE
update centos 7 mirror url

### DIFF
--- a/.ci/Dockerfile.centos7.7.1908
+++ b/.ci/Dockerfile.centos7.7.1908
@@ -6,6 +6,9 @@ ARG _LOGIN=jenkins
 ARG _HOME=/var/home/$_LOGIN
 USER root
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*; \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y \
     atk \
     autoconf \


### PR DESCRIPTION
Centos 7 is EOL and mirrorlist.centos.org is not
available anymore, thus switch to vault.centos.org