### PR TITLE
Improve podman docker image building performance

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1337,6 +1337,10 @@ spec:
                 container('docker') {
                     stage ('Build Docker') {
                         config.logger.debug("set symbolic link docker => podman (if doesn't exist)")
+                        //Podman image defaults to using fuse-overlayfs as the storage driver.
+                        //This is much slower on the kubernetes agent then using overlay2 storage driver.
+                        //So we need to remove the storage.conf file and reset the podman system.
+                        sh 'rm /etc/containers/storage.conf && podman system reset -f'
                         sh 'type -p docker || ln -sfT $(type -p podman) /usr/bin/docker'
                         buildDocker(image, config)
                     }


### PR DESCRIPTION
We see significent performance degradation in docker image build stage when using podman image builds can run upto 1 hour.

We susspect that it is caused by the default storage driver type overlay-fuse on podman images 5.2 and up.

To improve this we want to use overlay2 driver to do so we add a reset to podman storage conf which will remove the default commit from podman image and set it to overlay2.