### PR TITLE
Improve podman docker image building performance

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1337,6 +1337,11 @@ spec:
                 container('docker') {
                     stage ('Build Docker') {
                         config.logger.debug("set symbolic link docker => podman (if doesn't exist)")
+                        // Podman image defaults to using fuse-overlayfs as the storage driver.
+                        // This is much slower on the kubernetes agent then using overlay storage driver.
+                        // So we need to remove the storage.conf file and reset the podman system.
+                        // Also, for rare cases or none podman runs we dont fail the build.
+                        sh 'rm /etc/containers/storage.conf ; podman system reset -f || true'
                         sh 'type -p docker || ln -sfT $(type -p podman) /usr/bin/docker'
                         buildDocker(image, config)
                     }


### PR DESCRIPTION
We see significant performance degradation in docker image build stage when using podman image builds can run up to 1 hour.

We suspect that it is caused by the default storage driver type overlay-fuse on podman images 5.2 and up.
See more info in:
https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/5177034

To improve this we want to use overlay2 driver to do so we add a reset to podman storage conf which will remove the default config from podman image and set it to overlay2.