### PR TITLE
Add StringCredentialsImpl cretential type support

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -624,6 +624,13 @@ def run_step(image, config, title, oneStep, axis, runtime=null) {
                             credentials.add(file(credentialsId: found.credentialsId,
                                             variable: found.variable))
                         }
+                        if (found.type == 'string') {
+                            if (!found.variable) {
+                                reportFail(title, "credentialsId '${found.credentialsId}' has unsupported format (${found})! Missing 'variable' field.")
+                            }
+                            credentials.add(string(credentialsId: found.credentialsId,
+                                            variable: found.variable))
+                        }
                     } else {
                         // usernamePassword by default
                         if (!found.usernameVariable || !found.passwordVariable) {


### PR DESCRIPTION
The Matrix.groovy currently supports 3 types of Jenkins credentials: 
- sshUserPrivateKey - for SSH keys;
- usernamePassword - for user/password pairs;
- file (FileCredentialsImpl) - for secret files.
Here, I would like to add StringCredentialsImpl cred support, which is convenient for storing a single authentication key or token.