### PR TITLE
Add hostIPC support for Kubernetes pod templates

### DIFF
--- a/.ci/examples/job_matrix_hostipc.yaml
+++ b/.ci/examples/job_matrix_hostipc.yaml
@@ -1,0 +1,101 @@
+---
+# Example demonstrating hostIPC usage in CI/CD matrix jobs
+# hostIPC enables sharing the host's IPC namespace with the container
+# This is useful for applications that need to communicate via System V IPC
+# or POSIX message queues
+
+job: hostipc-demo
+
+registry_host: harbor.mellanox.com
+registry_path: /swx-storage/ci-demo
+registry_auth: swx-storage
+
+# Global hostIPC setting - applies to all containers unless overridden
+kubernetes:
+  cloud: swx-k8s
+  namespace: ci-demo
+  serviceAccount: jenkins
+  # Enable host IPC namespace sharing globally
+  hostIPC: true
+
+volumes:
+  - {mountPath: /hpc/local, hostPath: /hpc/local}
+  - {mountPath: /tmp, hostPath: /tmp}
+
+env:
+  # Environment variables for IPC testing
+  IPC_TEST_MESSAGE: "Hello from host IPC namespace"
+  SHM_SIZE: "1024"
+
+# Container definitions with different hostIPC settings
+runs_on_dockers:
+  # This container will use global hostIPC setting (true)
+  - {file: '.ci/Dockerfile.ubuntu16-4', name: 'ubuntu16-4-global', tag: 'latest'}
+
+  # This container explicitly enables hostIPC
+  - {file: '.ci/Dockerfile.ubuntu16-4', name: 'ubuntu16-4-explicit', tag: 'latest', hostIPC: true}
+
+  # This container explicitly disables hostIPC (overrides global setting)
+  - {file: '.ci/Dockerfile.ubuntu16-4', name: 'ubuntu16-4-disabled', tag: 'latest', hostIPC: false}
+
+matrix:
+  axes:
+    arch:
+      - x86_64
+    test_type:
+      - "shared_memory"
+      - "message_queue"
+
+steps:
+  - name: Test Shared Memory with hostIPC
+    # This step will only run on containers with hostIPC enabled
+    containerSelector: '{hostIPC: true}'
+    run: |
+      echo "Testing shared memory with host IPC namespace..."
+      # Create a shared memory segment
+      ipcmk -M 1024
+      # List shared memory segments
+      ipcs -m
+      echo "Shared memory test completed"
+
+  - name: Test Message Queue with hostIPC
+    # This step will only run on containers with hostIPC enabled
+    containerSelector: '{hostIPC: true}'
+    run: |
+      echo "Testing message queue with host IPC namespace..."
+      # Create a message queue
+      ipcmk -Q
+      # List message queues
+      ipcs -q
+      echo "Message queue test completed"
+
+  - name: Verify IPC isolation
+    # This step will run on all containers to show the difference
+    run: |
+      echo "Current container: ${name}"
+      echo "Host IPC enabled: ${hostIPC:-false}"
+      echo "Available shared memory segments:"
+      ipcs -m || echo "No shared memory segments or IPC not available"
+      echo "Available message queues:"
+      ipcs -q || echo "No message queues or IPC not available"
+
+  - name: Cleanup IPC resources
+    run: |
+      echo "Cleaning up IPC resources..."
+      # Remove any shared memory segments created by this process
+      ipcs -m | grep $(whoami) | awk '{print $2}' | xargs -r ipcrm -m
+      # Remove any message queues created by this process
+      ipcs -q | grep $(whoami) | awk '{print $2}' | xargs -r ipcrm -q
+      echo "IPC cleanup completed"
+
+# Pipeline hooks
+pipeline_start:
+  run: echo "Starting hostIPC demo job"
+
+pipeline_stop:
+  run: echo "HostIPC demo job completed"
+
+# Job configuration
+failFast: false
+batchSize: 2
+timeout_minutes: 30

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Matrix workflow project for CI/CD
 
-This is Jenkins CI/CD demo project. You can create custom workflows to automate your project software life cycle process. 
+This is Jenkins CI/CD demo project. You can create custom workflows to automate your project software life cycle process.
 
-You need to configure workflows using YAML syntax, and save them as workflow files in your repository. 
+You need to configure workflows using YAML syntax, and save them as workflow files in your repository.
 Once you've successfully created a YAML workflow file and triggered the workflow - Jenkins parse flow and execute it.
 
 
 ## Quick start
 
-1. Copy ```.ci/Jenkinsfile.shlib``` to your new github project, under ```.ci/``` 
+1. Copy ```.ci/Jenkinsfile.shlib``` to your new github project, under ```.ci/```
 
-2. Copy ```.ci/Makefile``` to your new github project, under ```.ci/``` 
+2. Copy ```.ci/Makefile``` to your new github project, under ```.ci/```
 
 3. Create ```.ci/job_matrix.yaml``` basic workflow file with content:
 
@@ -71,7 +71,7 @@ steps:
 
   - name: Install
     run: make -j 2 install
-     
+
 ```
 
 4. Copy ```.ci/proj_jjb.yaml``` to ```.ci``` folder in your project  and change github URL to point to your own github project as [here](.ci/proj_jjb.yaml#L67).
@@ -118,7 +118,7 @@ Jenkins behavior can be controlled by job_matrix.yaml file which has similar syn
 
 ## Jenkins job builder
 
-* Demo contains [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder) config [file](.ci/jjb_proj.yaml) 
+* Demo contains [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder) config [file](.ci/jjb_proj.yaml)
 which loads Jenkins project definition into Jenkins server.
 * Jenkins project descibed by [file](.ci/jjb_proj.yaml) supports following UI actions/parameters:
  - boolean - rebuild docker files
@@ -135,7 +135,7 @@ which loads Jenkins project definition into Jenkins server.
 % make shell NAME=ubuntu16-4
 docker%% cd /scratch
 
-# the step below needed so workspace files (which belongs to linux $USER) 
+# the step below needed so workspace files (which belongs to linux $USER)
 # will be copied (and owned) as Docker user 'jenkins' so it can be modified
 # from docker shell
 
@@ -284,6 +284,8 @@ kubernetes:
   caps_add: "[ IPC_LOCK, SYS_RESOURCE ]"
 # optional: tolerations. Tolerations allow the scheduler to schedule pods with matching taints.
   tolerations: "[{key: 'feature.node.kubernetes.io/project', operator: 'Equal', value: 'SPDK', effect: 'NoSchedule'}]"
+# optional: enable host IPC namespace sharing (default: false)
+  hostIPC: true
 
 # optional: can specify jenkins defined credentials and refer/request by credentialsId in step that
 # requires it
@@ -315,7 +317,7 @@ nfs_volumes:
   - {serverAddress: r1, serverPath: /vol/mtrswgwork, mountPath: /.autodirect/mtrswgwork}
   - {serverAddress: r3, serverPath: /vol/mlnx_ofed_release_flexcache, mountPath: /auto/sw/release/mlnx_ofed, readOnly: true}
 
-# environment varibles to insert into Job shell environment, can be referenced from steps 
+# environment varibles to insert into Job shell environment, can be referenced from steps
 # or user-scripts or shell commands.
 # If you want more detailed output in logs, add the following environment variable:
 # `DEBUG: true`
@@ -329,7 +331,7 @@ defaults:
   var1: value1
   var2: value2
 
-# list of dockers to use for the job, `file` key is optional, if defined but docker image 
+# list of dockers to use for the job, `file` key is optional, if defined but docker image
 # does not exist in registry.
 # `arch` key is optional, it defaults to `x86_64` unless specified otherwise.
 # image will be created during 1st invocation or if file was modified
@@ -337,10 +339,11 @@ defaults:
 # category:tools has special meaning - it will run for steps, that explicitly request it in the
 # step`s containerSelector key.
 # The use-case is as following: if some step requires special container with pre-installed toolchain (clang?)
+# `hostIPC` key is optional, enables host IPC namespace sharing for this specific container (default: false)
 
 runs_on_dockers:
   - {file: '.ci/Dockerfile.centos7.7.1908', name: 'centos7-7', tag: 'latest', category: 'tool'}
-  - {file: '.ci/Dockerfile.ubuntu16-4', name: 'ubuntu16-4', tag: 'latest'}
+  - {file: '.ci/Dockerfile.ubuntu16-4', name: 'ubuntu16-4', tag: 'latest', hostIPC: true}
 
 # list of jenkins agents labels to run on (optional)
 
@@ -375,7 +378,7 @@ matrix:
       - x86_64
 
 # include only dimensions as below. Exclude has same syntax. Only either include or exclude can be used.
-# all keywords in include/exclude command are optional - if all provided keys 
+# all keywords in include/exclude command are optional - if all provided keys
 # match - the dimension will be include/excluded
 
 include:
@@ -387,7 +390,7 @@ include:
 # every matrix dimension will run in parallel with all other dimensions
 # steps itself has sequential execution
 # NOTE:
-# shell environment variable representing dimension values will be inserted automatically and 
+# shell environment variable representing dimension values will be inserted automatically and
 # can be used run section (see below)
 # $name represents current value for docker name
 # Also $driver $cuda,$arch env vars are available and can be used from shell
@@ -400,12 +403,12 @@ steps:
 # with parameters
 # defined by `args` key.
     shell: action
-# dynamicAction is pre-defined action defined at https://github.com/Mellanox/ci-demo/blob/master/vars/dynamicAction.groovy 
+# dynamicAction is pre-defined action defined at https://github.com/Mellanox/ci-demo/blob/master/vars/dynamicAction.groovy
 # dynamicAction will execute ci-demo/vars/actions/$args[0] and will pass $args[1..] to it as command line arguments
     run: dynamicAction
 # step can specify containerSelector filter to apply on `runs_on_dockers` section.
 # make sure to quote the category.
-# `variant` is built-in variable, available for every axis of the run and represents serial number for 
+# `variant` is built-in variable, available for every axis of the run and represents serial number for
 # execution of matrix dimension
 # selector can be regex
     containerSelector: '{category:"tool", variant:1}'
@@ -470,7 +473,7 @@ archiveJunit: 'myproject/target/test-reports/*.xml'
 # Fail job is one of the steps fails or continue
 failFast: false
 
-# Execute parallel job in batches (default 10 jobs in the air), to prevent overload k8 
+# Execute parallel job in batches (default 10 jobs in the air), to prevent overload k8
 # with large amount of parallel jobs
 batchSize: 2
 

--- a/schema_validator/ci_demo_schema.yaml
+++ b/schema_validator/ci_demo_schema.yaml
@@ -3,6 +3,7 @@ job: str()
 kubernetes:
   cloud: str()
   nodeSelector: str()
+  hostIPC: bool(required=False)
 
 registry_host: str(required=False)
 registry_path: str(required=False)

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -41,7 +41,7 @@ class Logger {
     }
 
 }
- 
+
 @NonCPS
 List getMatrixAxes(matrix_axes) {
     List axes = []
@@ -58,7 +58,7 @@ List getMatrixAxes(matrix_axes) {
 
 // hack to avoid Serializble errors as intermediate access to entrySet returns non-serializable objects
 
-@NonCPS 
+@NonCPS
 def entrySet(m) {
     m.collect { k, v -> [key: k, value: v] }
 }
@@ -415,7 +415,7 @@ def getDefaultShell(config=null, step=null, shell=null) {
     """
     def res = run_shell(cmd, "Detect shell", true)
     shell = res.text.trim()
-    
+
     if (isDebugMode()) {
         shell += 'x'
     }
@@ -550,8 +550,8 @@ def toEnvVars(config, vars) {
 
 def run_step(image, config, title, oneStep, axis, runtime=null) {
 
-    if ((image != null) && 
-        (axis != null) && 
+    if ((image != null) &&
+        (axis != null) &&
         check_skip_stage(image, config, title, oneStep, axis, runtime)) {
         return
     }
@@ -633,7 +633,7 @@ def runSteps(image, config, branchName, axis, steps=config.steps, runtime) {
             }
             continue
         }
-        // non-parallel step discovered, need to flush all parallel 
+        // non-parallel step discovered, need to flush all parallel
         // steps collected previously to keep ordering.
         // run non-parallel step right after
         if (parallelNestedSteps.size() > 0) {
@@ -699,7 +699,7 @@ def parseListNfsV(volumes) {
     }
     return listV
 }
-        
+
 
 def parseListA(annotations) {
     def listA = []
@@ -745,6 +745,7 @@ def runK8(image, branchName, config, axis, steps=config.steps) {
         }
     }
     def hostNetwork = image.hostNetwork ?: getConfigVal(config, ['kubernetes', 'hostNetwork'], false)
+    def hostIPC = image.hostIPC ?: getConfigVal(config, ['kubernetes', 'hostIPC'], false)
     def runAsUser = image.runAsUser ?: getConfigVal(config, ['kubernetes', 'runAsUser'], "0")
     def runAsGroup = image.runAsGroup ?: getConfigVal(config, ['kubernetes', 'runAsGroup'], "0")
     def privileged = image.privileged ?: getConfigVal(config, ['kubernetes', 'privileged'], false)
@@ -757,6 +758,7 @@ def runK8(image, branchName, config, axis, steps=config.steps) {
     def tolerations = image.tolerations ?: getConfigVal(config, ['kubernetes', 'tolerations'], "[]")
     def yaml = """
 spec:
+  hostIPC: ${hostIPC}
   containers:
     - name: ${cname}
       resources:
@@ -949,7 +951,7 @@ Map getTasks(axes, image, config, include, exclude) {
             withEnv(axisEnv) {
                 if ((config.get("kubernetes") == null) &&
                     (image.nodeLabel == null) &&
-                    (image.cloud == null) 
+                    (image.cloud == null)
                     ) {
                     reportFail('config', "Please define cloud or nodeLabel in yaml config file or define nodeLabel for docker")
                 }
@@ -1396,7 +1398,7 @@ def startPipeline(String label) {
                     branches += getMatrixTasks(image, config)
                 }
             }
-        
+
             if (config.runs_on_agents) {
                 for (int a=0; a<config.runs_on_agents.size();a++) {
                     image = config.runs_on_agents[a]


### PR DESCRIPTION
- Add hostIPC option to runK8 and build_docker_on_k8 functions
- Support both global (kubernetes.hostIPC) and per-container (runs_on_dockers[].hostIPC) configuration
- hostIPC is defined in pod spec YAML rather than podTemplate parameters
- Update documentation in README.md with usage examples
- Add hostIPC to schema validator
- Create example YAML file demonstrating hostIPC usage with IPC testing

This enables sharing the host's IPC namespace with containers, useful for applications that need System V IPC or POSIX message queue communication.