### PR TITLE
slurmCI: fixed variable resolution

### DIFF
--- a/vars/slurmCI.groovy
+++ b/vars/slurmCI.groovy
@@ -1,7 +1,14 @@
 #!/usr/bin/env groovy
 
 int call(ctx, oneStep, config) {
-    def args = oneStep.args ?: [:]
+    // Deep-copy args so parallel matrix branches each get their own map
+    // and don't clobber each other's resolved values.
+    def args = [:]
+    if (oneStep.args) {
+        oneStep.args.each { k, v ->
+            args[k] = (v instanceof List) ? new ArrayList(v) : v
+        }
+    }
 
     // Load the shared Slurm helper library from the pipeline shared library.
     // refer to this doc for more details: https://www.jenkins.io/doc/book/pipeline/shared-libraries/#using-libraries
@@ -20,35 +27,12 @@ int call(ctx, oneStep, config) {
         return 1
     }
 
-    for (def entry in ctx.entrySet(args)) {
-        def original = entry.value.toString()
-        def resolved = ctx.resolveTemplate(['env': env], original, config)
-        // resolveTemplate is @NonCPS and cannot see withEnv-set axis vars (e.g. ucx_version, arch)
-        // via env.getEnvironment(). Do a second pass here in CPS context where env property
-        // access DOES include withEnv vars.
-        def pass2 = resolved
-        def safety = 0
-        while (pass2.contains('${') && safety++ < 20) {
-            def start = pass2.indexOf('${')
-            def end = pass2.indexOf('}', start)
-            if (end == -1) break
-            def varName = pass2.substring(start + 2, end)
-            def val = env."${varName}"
-            if (val != null) {
-                pass2 = pass2.substring(0, start) + val + pass2.substring(end + 1)
-            } else {
-                break
-            }
-        }
-        args[entry.key] = pass2
-    }
     def stepRun = oneStep.run
     def allowedOps = ['allocation', 'run', 'stop', 'stopAllForBuild'] as Set
     if (!allowedOps.contains(stepRun)) {
         ctx.reportFail(oneStep.name, "fatal: unsupported slurm operation '${stepRun}'; allowed: ${allowedOps.sort().join(', ')}")
         return 1
     }
-    println("Calling slurm.${stepRun} with args=" + args)
 
     def vars = []
     vars += ctx.toEnvVars(config, config.env)
@@ -56,6 +40,32 @@ int call(ctx, oneStep, config) {
 
     def rawResult = null
     withEnv(vars) {
+        // Resolve templates INSIDE withEnv so axis variables (ucx_version, arch, etc.)
+        // set by the outer withEnv in getTasks are visible via env property access.
+        for (def entry in ctx.entrySet(args)) {
+            def original = entry.value.toString()
+            def resolved = ctx.resolveTemplate(['env': env], original, config)
+            // resolveTemplate is @NonCPS and cannot see withEnv-set axis vars
+            // via env.getEnvironment(). Do a second pass here in CPS context where
+            // env property access DOES include withEnv vars.
+            def pass2 = resolved
+            def safety = 0
+            while (pass2.contains('${') && safety++ < 20) {
+                def start = pass2.indexOf('${')
+                def end = pass2.indexOf('}', start)
+                if (end == -1) break
+                def varName = pass2.substring(start + 2, end)
+                def val = env."${varName}"
+                if (val != null) {
+                    pass2 = pass2.substring(0, start) + val + pass2.substring(end + 1)
+                } else {
+                    break
+                }
+            }
+            args[entry.key] = pass2
+        }
+
+        println("Calling slurm.${stepRun} with args=" + args)
         rawResult = slurm."${stepRun}"(args)
     }
     if (rawResult == false) {


### PR DESCRIPTION
Clone args (line 4-9) — each parallel branch now gets its own map copy
(including deep-copying any list values like extraArgs), so resolving
${ucx_version} in branch A doesn't overwrite the template string
that branch B still needs.

Move resolution inside withEnv (line 35-55) — the template resolution
loop now runs inside withEnv(vars), so axis variables like ucx_version
from the outer withEnv in getTasks are actually visible when
env."${varName}" is accessed. Previously the resolution happened
before withEnv, so it could pick up stale or race-condition
values from the global env.

Signed-off-by: Iaroslav Sydoruk <isydoruk@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected argument isolation in parallel branch execution. Arguments are now properly scoped to individual branches, preventing cross-branch mutation and interference that could cause incorrect values to propagate between parallel workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->