### PR TITLE
Draft: feat(matrix): add sampleResources flag for cgroup pod profiling

### DIFF
--- a/resources/actions/resource_sampler.sh
+++ b/resources/actions/resource_sampler.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Continuous cgroup resource sampler for ci-demo pipeline pods.
+#
+# Usage (inside a step's `run:` block):
+#   bash ${WORKSPACE}/.ci/resource_sampler.sh start "${name}"
+#   bash ${WORKSPACE}/.ci/resource_sampler.sh report "${name}"
+#
+# `start`  spawns a detached background loop that appends one CSV line every
+#          SAMPLE_INTERVAL seconds (default: 2) to
+#          ${WORKSPACE}/resource_samples_<container>.csv until killed.
+# `report` stops the sampler, then summarises peak/p95/avg memory and CPU into
+#          ${WORKSPACE}/resource_summary_<container>.txt and stdout.
+#
+# Auto-detects cgroup v1 vs v2 (Blossom nodes are still on v1 as of writing).
+# Survives the parent shell exiting: stdio is redirected, SIGHUP is ignored,
+# the process is disowned. Idempotent — calling `start` again while a sampler
+# is already running is a no-op.
+
+set -u
+
+MODE="${1:-start}"
+CONTAINER="${2:-${name:-unknown}}"
+INTERVAL="${SAMPLE_INTERVAL:-2}"
+WS="${WORKSPACE:-/tmp}"
+OUT="${WS}/resource_samples_${CONTAINER}.csv"
+SUMMARY="${WS}/resource_summary_${CONTAINER}.txt"
+PIDFILE="/tmp/resource_sampler_${CONTAINER}.pid"
+
+# Detect cgroup mode once (v2 has /sys/fs/cgroup/cgroup.controllers; v1 doesn't).
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    CGROUP_MODE=v2
+elif [ -d /sys/fs/cgroup/memory ] && [ -d /sys/fs/cgroup/cpu,cpuacct ]; then
+    CGROUP_MODE=v1
+else
+    CGROUP_MODE=unknown
+fi
+
+sample_once() {
+    local ts cpu_usec mem_curr mem_peak mem_max cpu_max top_line top_rss top_pcpu top_comm
+    ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    case "$CGROUP_MODE" in
+        v2)
+            cpu_usec=$(awk '/^usage_usec/ {print $2; exit}' /sys/fs/cgroup/cpu.stat 2>/dev/null || echo 0)
+            mem_curr=$(cat /sys/fs/cgroup/memory.current 2>/dev/null || echo 0)
+            mem_peak=$(cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo 0)
+            mem_max=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo max)
+            cpu_max=$(tr ' ' '/' < /sys/fs/cgroup/cpu.max 2>/dev/null || echo max)
+            ;;
+        v1)
+            # v1 cpuacct.usage is in nanoseconds; convert to microseconds for schema parity.
+            local cpu_ns
+            cpu_ns=$(cat /sys/fs/cgroup/cpu,cpuacct/cpuacct.usage 2>/dev/null || echo 0)
+            cpu_usec=$(( cpu_ns / 1000 ))
+            mem_curr=$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2>/dev/null || echo 0)
+            mem_peak=$(cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes 2>/dev/null || echo 0)
+            mem_max=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo max)
+            local quota period
+            quota=$(cat /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us 2>/dev/null || echo -1)
+            period=$(cat /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us 2>/dev/null || echo 100000)
+            cpu_max="${quota}/${period}"
+            ;;
+        *)
+            cpu_usec=0; mem_curr=0; mem_peak=0; mem_max=max; cpu_max=max
+            ;;
+    esac
+    top_line=$(ps -eo rss,pcpu,comm --sort=-rss --no-headers 2>/dev/null | head -1 || true)
+    top_rss=$(printf '%s' "${top_line:-}" | awk '{print $1+0}')
+    top_pcpu=$(printf '%s' "${top_line:-}" | awk '{print $2+0}')
+    top_comm=$(printf '%s' "${top_line:-}" | awk '{print $3}')
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+        "$ts" "$CONTAINER" "$cpu_usec" "$mem_curr" "$mem_peak" \
+        "$mem_max" "$cpu_max" "${top_rss:-0}" "${top_pcpu:-0}" "${top_comm:-NA}" \
+        >> "$OUT"
+}
+
+start_daemon() {
+    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+        echo "[sampler] already running pid=$(cat "$PIDFILE")"
+        return 0
+    fi
+    if [ ! -f "$OUT" ]; then
+        printf 'timestamp,container,cpu_usage_usec,mem_current,mem_peak,mem_max,cpu_max,top_rss_kb,top_pcpu,top_comm\n' > "$OUT"
+    fi
+    (
+        trap '' HUP
+        exec </dev/null >/dev/null 2>&1
+        while :; do
+            sample_once
+            sleep "$INTERVAL"
+        done
+    ) &
+    local pid=$!
+    echo "$pid" > "$PIDFILE"
+    disown 2>/dev/null || true
+    echo "[sampler] started container=$CONTAINER pid=$pid interval=${INTERVAL}s out=$OUT"
+}
+
+stop_daemon() {
+    if [ -f "$PIDFILE" ]; then
+        local pid
+        pid=$(cat "$PIDFILE" 2>/dev/null || true)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            sleep 1
+        fi
+        rm -f "$PIDFILE"
+    fi
+}
+
+summarise() {
+    if [ ! -s "$OUT" ]; then
+        echo "[sampler] no samples for $CONTAINER" | tee "$SUMMARY"
+        return 0
+    fi
+    python3 - "$OUT" "$CONTAINER" "$INTERVAL" > "$SUMMARY" <<'PY'
+import csv, sys
+
+path, container, interval = sys.argv[1], sys.argv[2], float(sys.argv[3])
+
+rows = []
+with open(path) as f:
+    for r in csv.DictReader(f):
+        rows.append(r)
+
+def to_int(s, default=0):
+    try:
+        return int(s)
+    except Exception:
+        return default
+
+def fmt_b(n):
+    if n >= 1024 ** 3:
+        return f"{n / 1024 ** 3:.2f}Gi"
+    return f"{n / 1024 ** 2:.1f}Mi"
+
+def pct(xs, p):
+    if not xs:
+        return 0
+    xs = sorted(xs)
+    idx = max(0, min(len(xs) - 1, int(round(len(xs) * p)) - 1))
+    return xs[idx]
+
+mem_curr = [to_int(r["mem_current"]) for r in rows if to_int(r["mem_current"]) > 0]
+mem_peak = [to_int(r["mem_peak"]) for r in rows if to_int(r["mem_peak"]) > 0]
+cpu_usec = [to_int(r["cpu_usage_usec"]) for r in rows]
+
+print(f"=== container={container} samples={len(rows)} ===")
+if rows:
+    print(f"span: {rows[0]['timestamp']} -> {rows[-1]['timestamp']}")
+    print(f"cpu_max (cgroup): {rows[-1]['cpu_max']}    mem_max (cgroup): {rows[-1]['mem_max']}")
+
+if mem_curr:
+    print(f"memory.current  max={fmt_b(max(mem_curr))}  p95={fmt_b(pct(mem_curr, 0.95))}  "
+          f"p50={fmt_b(pct(mem_curr, 0.50))}  avg={fmt_b(sum(mem_curr) // len(mem_curr))}")
+if mem_peak:
+    print(f"memory.peak (cgroup high-water): {fmt_b(max(mem_peak))}")
+
+cpu_usec = [c for c in cpu_usec if c > 0]
+if len(cpu_usec) >= 2:
+    total_cpu_sec = (cpu_usec[-1] - cpu_usec[0]) / 1_000_000
+    span_s = (len(cpu_usec) - 1) * interval
+    avg_cores = total_cpu_sec / span_s if span_s else 0
+    deltas = [(cpu_usec[i + 1] - cpu_usec[i]) / 1_000_000 / interval
+              for i in range(len(cpu_usec) - 1)]
+    peak_cores = max(deltas) if deltas else 0
+    p95_cores = pct(deltas, 0.95) if deltas else 0
+    print(f"cpu  avg={avg_cores:.2f} cores  p95={p95_cores:.2f} cores  "
+          f"peak={peak_cores:.2f} cores  total={total_cpu_sec:.1f} CPU-sec / {span_s:.0f}s wall")
+
+# Suggested requests/limits from observed data.
+if mem_curr:
+    req_mem = max(512 * 1024 * 1024, int(pct(mem_curr, 0.95) * 1.30))
+    lim_mem = max(req_mem, int((max(mem_peak) if mem_peak else max(mem_curr)) * 1.50))
+    print(f"suggested  requests.memory={fmt_b(req_mem)}  limits.memory={fmt_b(lim_mem)}")
+if len(cpu_usec) >= 2:
+    p95 = pct(deltas, 0.95) if deltas else 0
+    peak = max(deltas) if deltas else 0
+    req_cpu = max(0.5, p95 * 1.30)
+    lim_cpu = max(req_cpu, peak * 1.50)
+    print(f"suggested  requests.cpu={req_cpu:.2f}  limits.cpu={lim_cpu:.2f}")
+PY
+    cat "$SUMMARY"
+}
+
+case "$MODE" in
+    start)  start_daemon ;;
+    stop)   stop_daemon ;;
+    report) stop_daemon; summarise ;;
+    *)
+        echo "usage: $0 {start|stop|report} <container_name>" >&2
+        exit 2
+        ;;
+esac

--- a/resources/actions/resource_sampler.sh
+++ b/resources/actions/resource_sampler.sh
@@ -74,6 +74,14 @@ sample_once() {
 }
 
 start_daemon() {
+    # Parallel steps share a container, so the check/start/write below is a
+    # TOCTOU pair. Guard it with an atomic mkdir lock so start stays idempotent.
+    if ! mkdir "${PIDFILE}.lock" 2>/dev/null; then
+        echo "[sampler] start already in progress for $CONTAINER"
+        return 0
+    fi
+    trap 'rmdir "${PIDFILE}.lock" 2>/dev/null || true' RETURN
+
     if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
         echo "[sampler] already running pid=$(cat "$PIDFILE")"
         return 0

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -693,6 +693,16 @@ def runSteps(image, config, branchName, axis, steps=config.steps, runtime) {
     unstashWS(getStashName(), config)
     onUnstash()
 
+    // sampleResources: deliver the cgroup sampler into this container's
+    // workspace once, after unstash. The synthetic step injection in
+    // loadConfigFile() expects it at .ci/actions/resource_sampler.sh.
+    if (config.sampleResources == true) {
+        def script = libraryResource('actions/resource_sampler.sh')
+        sh(script: 'mkdir -p .ci/actions', label: 'Create sampler dir', returnStatus: true)
+        writeFile(file: '.ci/actions/resource_sampler.sh', text: script)
+        sh(script: 'chmod +x .ci/actions/resource_sampler.sh', label: 'chmod sampler', returnStatus: true)
+    }
+
     def parallelNestedSteps = [:]
     for (int i = 0; i < steps.size(); i++) {
         def one = steps[i]
@@ -1519,7 +1529,35 @@ def loadConfigFile(filepath, logger) {
             reportFail('config', "matrix.include and matrix.exclude sections in config file=${filepath} are mutually exclusive. Please keep only one.")
         }
     }
+    if (config.sampleResources == true) {
+        instrumentResourceSampling(config, logger)
+    }
     return config
+}
+
+// Rewrite config.steps in place when sampleResources is enabled: prepend a
+// sampler-start invocation to every shell step's run-block and append a
+// synthetic "Resource report" step that runs in every container, stops the
+// sampler, archives the CSV and summary. The script itself is delivered into
+// each container's workspace by runSteps() via libraryResource.
+def instrumentResourceSampling(config, logger) {
+    def starter = 'bash ${WORKSPACE}/.ci/actions/resource_sampler.sh start "${name}" || true'
+    config.steps?.each { step ->
+        if (step.shell == 'action') { return }   // groovy modules: skip
+        if (step.run == null) { return }
+        step.run = starter + "\n" + step.run
+    }
+    if (config.runs_on_dockers) {
+        def selectors = config.runs_on_dockers.collect { "{name:\"${it.name}\"}" }
+        def report = [
+            name: 'Resource report',
+            containerSelector: selectors,
+            run: 'bash ${WORKSPACE}/.ci/actions/resource_sampler.sh report "${name}" || true',
+        ]
+        report.put('archiveArtifacts', 'resource_samples_*.csv,resource_summary_*.txt')
+        config.steps = (config.steps ?: []) + report
+        logger.debug("sampleResources: appended synthetic 'Resource report' step covering ${selectors.size()} containers")
+    }
 }
 
 def String getStashName() {


### PR DESCRIPTION
## Summary

- New opt-in top-level flag `sampleResources: true` (sibling of `failFast` / `timeout_minutes`) that auto-instruments every container in the matrix with a cgroup sampler
- `loadConfigFile` rewrites `config.steps` in place: prepends a sampler-start to each shell step's `run`, appends a synthetic "Resource report" step
- `runSteps` writes the sampler from `libraryResource('actions/resource_sampler.sh')` into the workspace once per container after unstash
- Sampler auto-detects cgroup v1 (current Blossom layout) and v2; reports peak / p95 / p50 / avg memory and CPU; archives raw CSV + summary

## Why

Sizing `kubernetes.requests` and `kubernetes.limits` for a new pipeline has been guesswork — under-size and the build OOMKills, over-size and the namespace queues. We had no built-in way to measure what pods actually use during a build. The same flag also helps catch pod-sizing regressions on existing pipelines (e.g. a new test that suddenly doubles memory).

## Design notes

- Placement: top-level (not under `kubernetes:`) because everything in the `kubernetes:` block is pod-spec / scheduling shape (`nodeSelector`, `tolerations`, `limits`). This is a pipeline-wide observability switch that happens to read cgroup files — sibling of `failFast`, not of `nodeSelector`.
- Action-shell steps (`shell: action`, groovy modules) are skipped — sampler is only prepended to shell steps.
- The synthetic Resource report step's `containerSelector` is built dynamically from `runs_on_dockers[].name` so it runs in every container.
- Sampler is idempotent (PID file) so multiple `start` calls per container collapse to one daemon.
- Cost when disabled: zero (no code path entered).
- Cost when enabled: ~50 bytes/container/2s of CSV + one bg process; negligible.

## Test plan

- [ ] Enable on cloudaix's release pipeline (set `sampleResources: true` in `.ci/job_matrix.yaml`, remove the manual sampler wiring), confirm build succeeds and artifacts appear
- [ ] Confirm cgroup v1 path works on Blossom (`yok-t-ipp-blossom-prod`) — pods run with v1 cgroups
- [ ] Verify `resource_samples_*.csv` and `resource_summary_*.txt` are archived per container
- [ ] Run on a pipeline that uses `shell: action` for a step — confirm sampler is not injected into the action step
- [ ] Run on a pipeline that already uses per-step `resource:` (e.g. coverity.sh) — confirm no conflict (sampler delivery in `runSteps` is independent of per-step `resource:` mechanism)
- [ ] Confirm summary requires `python3` in the container; falls back gracefully when absent (raw CSV still archived)

## Follow-up

Once this lands on `@stable`, the manual sampler wiring in `cloudaix/.ci/job_matrix.yaml` (separate branch `ci/resource-limits-and-requests`) can be replaced with a single `sampleResources: true` line.

Refs: HPCINFRA-4329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated container resource monitoring during CI with start/stop/report modes for continuous CPU and memory sampling.
  * Pipeline integration so sampling runs alongside steps and produces per-run CSVs plus a human-readable summary report.
  * Outputs concise statistics (p50/p95/avg/peak) and suggested Kubernetes-style memory and CPU requests/limits; handles missing samples gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->