### PR TITLE
feat(modules): add nvbugs ci-demo module

### DIFF
--- a/.ci/examples/job_matrix_nvbugs.yaml
+++ b/.ci/examples/job_matrix_nvbugs.yaml
@@ -1,0 +1,42 @@
+---
+# Example: NVBugs PR/commit gate via the `nvbugs` ci-demo module.
+#
+# The module is self-dispatching:
+#   - Reads the latest commit's message + author email from
+#     currentBuild.changeSets (Jenkins-side data; no git binary or
+#     ghprb plugin required)
+#   - Greps for 'nvbug: <id>' (case-insensitive) in the commit message
+#   - If found, fetches the bug via the NVBugs REST API and verifies it
+#     belongs to a configured module and is assigned to the commit author
+#   - If no 'nvbug: <id>' tag is present, fails the build (rc=1)
+#
+# The Bearer token is read from a Jenkins string credential whose ID is
+# passed as `credentials_id`. The credential is exposed to the helper
+# script as NVBUGS_API_TOKEN.
+#
+# Runtime requirement: python3 (stdlib only) on the executor. No git,
+# no ghprb. No containerSelector is needed when the job has a single
+# runs_on_dockers entry; add one only if you have multiple runtimes and
+# want to pin the check to a specific image.
+job: example-nvbugs
+
+kubernetes:
+  cloud: 'swx-k8s-spray'
+
+runs_on_dockers:
+  - {name: 'ub22.04-base', url: 'harbor.mellanox.com/hpcx/x86_64/ubuntu22.04/base', arch: 'x86_64'}
+
+steps:
+  - name: NVBug check
+    shell: action
+    module: nvbugs
+    args:
+      # Required: numeric NVBugs ModuleInfo.Key the bug must belong to.
+      # Use `module_name` instead to match by ModuleInfo.Value string.
+      module_id: 12345
+      # Required: Jenkins string credential ID holding the NVBugs Bearer token.
+      credentials_id: nvbugs_api_token
+      # Optional, defaults shown:
+      on_email_mismatch: warn         # warn | fail
+      on_bug_not_in_module: fail      # warn | fail
+      # api_url: https://prod.api.nvidia.com/int/nvbugs

--- a/resources/actions/check_nvbugs.py
+++ b/resources/actions/check_nvbugs.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Verify an NVBugs bug matches a configured module and assigned engineer.
+
+Pure HTTP client. The caller (the `nvbugs` ci-demo module) is responsible
+for extracting the bug ID and commit author email from Jenkins state and
+passing them in via --bug-id and --author-email.
+
+Reads the API Bearer token from NVBUGS_API_TOKEN env var.
+
+Exit codes:
+  0 - bug checks passed
+  1 - bug-check failed (module mismatch, email mismatch, API error)
+"""
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEFAULT_API_URL = "https://prod.api.nvidia.com/int/nvbugs"
+# Allow-list of trusted NVBugs API hosts. The Bearer token is sent here, so
+# the list is restricted to known endpoints from the NVBugs REST API docs.
+ALLOWED_API_HOSTS = frozenset({
+    "prod.api.nvidia.com",
+    "dev.api.nvidia.com",
+    "nvbugsapi.nvidia.com",
+    "stbugsapi.nvidia.com",
+})
+MODULE_PLACEHOLDER = "TBD_FILL_IN"
+
+
+def log(msg):
+    print(f"[check_nvbugs] {msg}", flush=True)
+
+
+def fail(msg):
+    log(f"FAIL: {msg}")
+    sys.exit(1)
+
+
+def warn(msg):
+    log(f"WARN: {msg}")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--bug-id", required=True, type=int)
+    p.add_argument("--author-email", required=True)
+    p.add_argument("--commit-sha", default="",
+                   help="Commit SHA for log context; not used for any check.")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--module-id",
+                   help="Numeric NVBugs ModuleInfo.Key to match against.")
+    g.add_argument("--module-name",
+                   help="NVBugs ModuleInfo.Value to match against.")
+    p.add_argument("--on-email-mismatch", choices=["warn", "fail"], default="warn")
+    p.add_argument("--on-bug-not-in-module", choices=["warn", "fail"], default="fail")
+    p.add_argument("--api-url", default=DEFAULT_API_URL)
+    return p.parse_args()
+
+
+def validate_api_url(api_url):
+    parsed = urllib.parse.urlparse(api_url)
+    if parsed.scheme != "https":
+        fail(f"refusing to send Bearer token over non-HTTPS scheme {parsed.scheme!r}")
+    host = (parsed.hostname or "").lower()
+    if host not in ALLOWED_API_HOSTS:
+        fail(f"--api-url host {host!r} is not in the allow-list "
+             f"{sorted(ALLOWED_API_HOSTS)}")
+
+
+def fetch_bug(api_url, bug_id, token):
+    url = f"{api_url.rstrip('/')}/api/Bug/GetBug/{bug_id}"
+    req = urllib.request.Request(url)
+    req.add_header("Content-type", "application/json")
+    req.add_header("Authorization", f"Bearer {token}")
+    log(f"GET {url}")
+    try:
+        with urllib.request.urlopen(req, timeout=30,
+                                    context=ssl.create_default_context()) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            fail(f"bug {bug_id} not found (HTTP 404)")
+        fail(f"API error {e.code} {e.reason}")
+    except urllib.error.URLError as e:
+        fail(f"connection error: {e.reason}")
+    except json.JSONDecodeError as e:
+        fail(f"response parse error: {e}")
+    return data.get("ReturnValue") or {}
+
+
+def main():
+    args = parse_args()
+
+    if args.module_id == MODULE_PLACEHOLDER or args.module_name == MODULE_PLACEHOLDER:
+        fail(f"module identifier still set to placeholder {MODULE_PLACEHOLDER!r}")
+
+    validate_api_url(args.api_url)
+
+    author_email = (args.author_email or "").strip().lower()
+    log(f"Commit         : {args.commit_sha or '<unknown>'}")
+    log(f"NVBug reference: {args.bug_id}")
+
+    token = os.environ.get("NVBUGS_API_TOKEN")
+    if not token:
+        fail("NVBUGS_API_TOKEN env var not set (expected from Jenkins credentialsId)")
+
+    bug = fetch_bug(args.api_url, args.bug_id, token)
+    if not bug:
+        fail(f"bug {args.bug_id}: empty ReturnValue from API")
+
+    log(f"Bug {args.bug_id} BugAction: {(bug.get('BugAction') or {}).get('Value')}")
+
+    module_info = bug.get("ModuleInfo") or {}
+    bug_module_id = module_info.get("Key")
+    bug_module_name = module_info.get("Value")
+    log(f"Bug {args.bug_id} Module   : Key={bug_module_id} Value={bug_module_name!r}")
+
+    if args.module_id is not None:
+        try:
+            module_ok = str(bug_module_id) == str(int(args.module_id))
+        except ValueError:
+            fail(f"--module-id must be an integer, got {args.module_id!r}")
+    else:
+        module_ok = (bug_module_name or "").strip().lower() == args.module_name.strip().lower()
+
+    failures = []
+    if not module_ok:
+        expected = args.module_id if args.module_id is not None else args.module_name
+        msg = (f"bug {args.bug_id} is in module {bug_module_name!r} "
+               f"(Key={bug_module_id}), expected {expected!r}")
+        if args.on_bug_not_in_module == "fail":
+            failures.append(msg)
+        else:
+            warn(msg)
+
+    bug_email = (bug.get("EngineerEmailID") or "").strip().lower()
+    if not author_email:
+        msg = "commit author email is empty"
+        if args.on_email_mismatch == "fail":
+            failures.append(msg)
+        else:
+            warn(msg)
+    elif bug_email != author_email:
+        msg = (f"bug {args.bug_id} Engineer email {bug_email!r} does not match "
+               f"commit author email {author_email!r}")
+        if args.on_email_mismatch == "fail":
+            failures.append(msg)
+        else:
+            warn(msg)
+
+    if failures:
+        for msg in failures:
+            log(f"FAIL: {msg}")
+        sys.exit(1)
+
+    log(f"OK: bug {args.bug_id} checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vars/nvbugs.groovy
+++ b/vars/nvbugs.groovy
@@ -1,0 +1,102 @@
+#!/usr/bin/env groovy
+
+int call(ctx, oneStep, config) {
+    def args = (oneStep.args ?: [:]).clone()
+
+    for (def entry in ctx.entrySet(args)) {
+        args[entry.key] = ctx.resolveTemplate(['env': env], entry.value.toString(), config)
+    }
+
+    def credentialsId = args.credentials_id
+    if (!credentialsId) {
+        ctx.reportFail(oneStep.name, "fatal: nvbugs module requires 'credentials_id' arg (Jenkins string credential holding the NVBugs Bearer token)")
+        return 1
+    }
+
+    def moduleId = args.module_id
+    def moduleName = args.module_name
+    if (!moduleId && !moduleName) {
+        ctx.reportFail(oneStep.name, "fatal: nvbugs module requires 'module_id' or 'module_name' arg")
+        return 1
+    }
+    if (moduleId && moduleName) {
+        ctx.reportFail(oneStep.name, "fatal: nvbugs module: pass either 'module_id' OR 'module_name', not both")
+        return 1
+    }
+
+    def onEmailMismatch = args.on_email_mismatch ?: 'warn'
+    def onBugNotInModule = args.on_bug_not_in_module ?: 'fail'
+    def apiUrl = args.api_url ?: ''
+
+    // Commit info comes from Jenkins changeSets - no git binary or ghprb required.
+    def commitMsg = ''
+    def authorEmail = ''
+    def commitSha = env.GIT_COMMIT ?: ''
+    def changeSets = currentBuild.changeSets ?: []
+    if (changeSets.size() > 0) {
+        def lastSet = changeSets[changeSets.size() - 1]
+        def items = lastSet.items
+        if (items && items.length > 0) {
+            def latest = items[items.length - 1]
+            commitMsg = latest.msg ?: ''
+            authorEmail = latest.authorEmail ?: ''
+            if (!commitSha) commitSha = latest.commitId ?: ''
+        }
+    }
+    if (!commitMsg) {
+        ctx.reportFail(oneStep.name, "fatal: nvbugs module could not read commit message from currentBuild.changeSets (empty - retriggered build with no SCM changes?)")
+        return 1
+    }
+
+    def matcher = (commitMsg =~ /(?i)nvbug:\s*(\d+)/)
+    if (!matcher.find()) {
+        ctx.reportFail(oneStep.name, "fatal: no 'nvbug: <id>' tag found in latest commit message")
+        return 1
+    }
+    def bugId = matcher.group(1)
+
+    def scriptContent = libraryResource 'actions/check_nvbugs.py'
+    def scriptPath = '.ci/actions/check_nvbugs.py'
+    sh(script: "mkdir -p .ci/actions", label: "create .ci/actions dir")
+    writeFile file: scriptPath, text: scriptContent
+    sh(script: "chmod +x ${scriptPath}", label: "chmod +x ${scriptPath}")
+
+    // Pass user-controlled values through env vars to avoid shell injection
+    // via crafted values (e.g. a malicious git author email with shell
+    // metacharacters). Double-quoted "$VAR" shell expansion does NOT re-parse
+    // the value for command substitution, so this is safe regardless of
+    // contents.
+    def stepEnv = [
+        "NVBUG_BUG_ID=${bugId}",
+        "NVBUG_AUTHOR_EMAIL=${authorEmail}",
+        "NVBUG_COMMIT_SHA=${commitSha}",
+        "NVBUG_MODULE_ID=${moduleId ?: ''}",
+        "NVBUG_MODULE_NAME=${moduleName ?: ''}",
+        "NVBUG_ON_EMAIL_MISMATCH=${onEmailMismatch}",
+        "NVBUG_ON_BUG_NOT_IN_MODULE=${onBugNotInModule}",
+        "NVBUG_API_URL=${apiUrl}",
+    ]
+
+    def cli = "python3 ${scriptPath}"
+    cli += ' --bug-id="$NVBUG_BUG_ID"'
+    cli += ' --author-email="$NVBUG_AUTHOR_EMAIL"'
+    cli += ' --on-email-mismatch="$NVBUG_ON_EMAIL_MISMATCH"'
+    cli += ' --on-bug-not-in-module="$NVBUG_ON_BUG_NOT_IN_MODULE"'
+    if (commitSha)  cli += ' --commit-sha="$NVBUG_COMMIT_SHA"'
+    if (moduleId)   cli += ' --module-id="$NVBUG_MODULE_ID"'
+    if (moduleName) cli += ' --module-name="$NVBUG_MODULE_NAME"'
+    if (apiUrl)     cli += ' --api-url="$NVBUG_API_URL"'
+
+    def vars = []
+    vars += ctx.toEnvVars(config, config.env)
+    vars += ctx.toEnvVars(config, oneStep.env)
+    vars += stepEnv
+
+    int rc = 0
+    withEnv(vars) {
+        withCredentials([string(credentialsId: credentialsId, variable: 'NVBUGS_API_TOKEN')]) {
+            rc = sh(script: cli, returnStatus: true)
+        }
+    }
+    return rc
+}


### PR DESCRIPTION
Adds a self-dispatching ci-demo module that gates a PR/commit on a
linked NVBugs bug. The module reads the latest commit's message and
author email from currentBuild.changeSets (Jenkins-side parsed SCM
data), greps for 'nvbug: <id>' (case-insensitive), fetches the bug via
the NVBugs REST API (GET /api/Bug/GetBug/<id> with a Bearer token),
and verifies:
  - the bug belongs to a configured ModuleInfo (by module_id or
    module_name)
  - the bug's assigned Engineer email matches the commit author email

No git binary or ghprb plugin dependency. The only runtime requirement
on the executor is python3 (stdlib only) - the helper script makes no
shell-outs, just HTTPS + JSON.

Files:
  - resources/actions/check_nvbugs.py - pure HTTP client. Takes
    --bug-id, --author-email (both required), --module-id|--module-name,
    optional --commit-sha (for log context only), and mismatch flags.
    Smoke-tested against bug 6062575: match passes rc=0; wrong module
    fails rc=1 (default) or warns+passes (on-bug-not-in-module=warn);
    placeholder module fails fast; 404 fails clearly; missing required
    arg returns argparse rc=2.
  - vars/nvbugs.groovy - thin wrapper. Validates args (credentials_id,
    module_id|module_name required), extracts commit info from
    currentBuild.changeSets (fails loudly if empty), parses the nvbug
    tag, ships the python helper via libraryResource, wraps the sh call
    in withCredentials to expose the Jenkins string credential as
    NVBUGS_API_TOKEN.
  - .ci/examples/job_matrix_nvbugs.yaml - usage example.

Exit rc=1 when no 'nvbug:' tag is found is intentional: if a consumer
has chosen to run the check (gated via their own dispatcher), a missing
tag is a misconfiguration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/ci-demo/pull/148)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an example CI job to run an NVBugs validation step during builds.
  * Added a command-line NVBugs checker that validates a bug ID and commit author, using an API token from the environment.
  * CI step extracts an nvbug: <id> tag from the latest commit and will fail the build if absent or if configured checks (module membership / email) fail; mismatch behavior is configurable (warn or fail).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/ci-demo/pull/148)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->