### PR TITLE
feat(antivirusCI): Add bridge to swx-jenkins-lib's antivirus var

### DIFF
--- a/.ci/examples/job_matrix_antivirus.yaml
+++ b/.ci/examples/job_matrix_antivirus.yaml
@@ -1,0 +1,33 @@
+---
+# Example matrix that runs the GLIT antivirus scanner via the `antivirus`
+# var in Mellanox-lab/swx-jenkins-lib. The executing container must have
+# /auto/GLIT mounted (hostPath volume below).
+
+job: antivirus-example
+
+failFast: false
+timeout_minutes: 30
+
+kubernetes:
+  cloud: swx-k8s
+  nodeSelector: 'kubernetes.io/arch=amd64'
+
+volumes:
+  - {mountPath: /auto/GLIT, hostPath: /auto/GLIT}
+
+runs_on_dockers:
+  - url: 'ubuntu:22.04'
+    name: 'av_runner'
+    tag: '22.04'
+    arch: 'x86_64'
+
+steps:
+  - name: Antivirus scan
+    shell: action
+    module: antivirusCI
+    run: scan
+    containerSelector: '{name:"av_runner"}'
+    args:
+      path: '${RELEASE_PATH}'
+      skipIfMissing: true
+    archiveArtifacts: 'logs/antivirus_*.log'

--- a/.ci/examples/job_matrix_antivirus.yaml
+++ b/.ci/examples/job_matrix_antivirus.yaml
@@ -8,6 +8,10 @@ job: antivirus-example
 failFast: false
 timeout_minutes: 30
 
+env:
+  # Default keeps the example self-contained; override for a real release path.
+  RELEASE_PATH: '/auto/GLIT'
+
 kubernetes:
   cloud: swx-k8s
   nodeSelector: 'kubernetes.io/arch=amd64'

--- a/vars/antivirusCI.groovy
+++ b/vars/antivirusCI.groovy
@@ -10,7 +10,10 @@ int call(ctx, oneStep, config) {
     if (libRef) {
         library(identifier: "swx-jenkins-lib@${libRef}")
     } else {
-        library('swx-jenkins-lib')
+        // TEMP: load swx-jenkins-lib from the fork branch carrying the
+        // antivirus var (https://github.com/Mellanox-lab/swx-jenkins-lib/pull/4).
+        // Revert to library('swx-jenkins-lib') before merging.
+        library('github.com/orbalayla-nvidia/swx-jenkins-lib@feat/antivirus')
     }
 
     if (!args || args.size() < 1) {

--- a/vars/antivirusCI.groovy
+++ b/vars/antivirusCI.groovy
@@ -1,0 +1,53 @@
+#!/usr/bin/env groovy
+
+// Matrix-side bridge to the `antivirus` var in Mellanox-lab/swx-jenkins-lib.
+// Modeled on slurmCI.
+
+int call(ctx, oneStep, config) {
+    def args = (oneStep.args ?: [:]).clone()
+
+    def libRef = args.remove('ref')
+    if (libRef) {
+        library(identifier: "swx-jenkins-lib@${libRef}")
+    } else {
+        library('swx-jenkins-lib')
+    }
+
+    if (!args || args.size() < 1) {
+        ctx.reportFail(oneStep.name, 'antivirusCI: at least one arg required (path or paths)')
+        return 1
+    }
+
+    // Resolve ${VAR} on String values only; lists pass through.
+    for (def entry in ctx.entrySet(args)) {
+        if (!(entry.value instanceof String)) continue
+        def resolved = ctx.resolveTemplate(['env': env], entry.value, config)
+        def pass2 = resolved
+        def safety = 0
+        while (pass2.contains('${') && safety++ < 20) {
+            def start = pass2.indexOf('${')
+            def end = pass2.indexOf('}', start)
+            if (end == -1) break
+            def name = pass2.substring(start + 2, end)
+            def val = env."${name}"
+            if (val == null) break
+            pass2 = pass2.substring(0, start) + val + pass2.substring(end + 1)
+        }
+        args[entry.key] = pass2
+    }
+
+    def vars = []
+    vars += ctx.toEnvVars(config, config.env)
+    vars += ctx.toEnvVars(config, oneStep.env)
+
+    int rc = 0
+    withEnv(vars) {
+        try {
+            antivirus.scan(args)
+        } catch (Throwable t) {
+            ctx.reportFail(oneStep.name, "antivirus.scan failed: ${t.message}")
+            rc = 1
+        }
+    }
+    return rc
+}

--- a/vars/antivirusCI.groovy
+++ b/vars/antivirusCI.groovy
@@ -16,8 +16,8 @@ int call(ctx, oneStep, config) {
         library('github.com/orbalayla-nvidia/swx-jenkins-lib@feat/antivirus')
     }
 
-    if (!args || args.size() < 1) {
-        ctx.reportFail(oneStep.name, 'antivirusCI: at least one arg required (path or paths)')
+    if (!(args?.containsKey('path') || args?.containsKey('paths'))) {
+        ctx.reportFail(oneStep.name, "antivirusCI: 'path' or 'paths' arg required")
         return 1
     }
 
@@ -47,8 +47,10 @@ int call(ctx, oneStep, config) {
     withEnv(vars) {
         try {
             antivirus.scan(args)
-        } catch (Throwable t) {
-            ctx.reportFail(oneStep.name, "antivirus.scan failed: ${t.message}")
+        } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException fie) {
+            throw fie
+        } catch (Exception e) {
+            ctx.reportFail(oneStep.name, "antivirus.scan failed: ${e.message}")
             rc = 1
         }
     }


### PR DESCRIPTION
Matrix-side bridge to the `antivirus` var in [Mellanox-lab/swx-jenkins-lib#4](https://github.com/Mellanox-lab/swx-jenkins-lib/pull/4). Shape mirrors `slurmCI`: argument template resolution, optional `ref` to pin a library version, single supported op (`scan`).

Usage from a matrix:

```yaml
- name: Antivirus scan
  shell: action
  module: antivirusCI
  run: scan
  containerSelector: '{name:"some_container"}'
  args:
    path: '/abs/path'
    skipIfMissing: true   # optional
  archiveArtifacts: 'logs/antivirus_*.log'
```

The example under `.ci/examples/job_matrix_antivirus.yaml` shows it standalone. First real caller: https://github.com/Mellanox/cloudaix/pull/562.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated antivirus scanning into CI with configurable scan paths, argument templating, environment merging, validation, and failure reporting.
* **Chores**
  * Added an example CI job matrix for antivirus scans with runner configuration, log archiving, non-fail-fast behavior, and a 30-minute timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->