### PR TITLE
Verify pushed Docker images

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1187,6 +1187,28 @@ def buildImage(img, filename, extra_args, config, image) {
     }
     customImage = docker.build("${img}", "-f ${filename} ${extra_args} . ")
     customImage.push()
+    verifyImageInRegistry(img, config)
+}
+
+def verifyImageInRegistry(String img, config) {
+    def quotedImg = "'" + img.replaceAll("'", "'\\\\''") + "'"
+    def attempts = 6
+    def delaySeconds = 10
+
+    for (int i=1; i<=attempts; i++) {
+        def result = run_shell("docker manifest inspect ${quotedImg}", "Verify pushed image in registry", false)
+        if (result.rc == 0) {
+            config.logger.info("Verified pushed image in registry - ${img}")
+            return
+        }
+
+        if (i < attempts) {
+            config.logger.warn("Pushed image is not visible in registry yet - ${img} - retry ${i}/${attempts}")
+            sleep(time: delaySeconds, unit: 'SECONDS')
+        }
+    }
+
+    reportFail('docker push', "Pushed image ${img} is not visible in registry after ${attempts} attempts")
 }
 
 Boolean isEnvVarSet(var) {


### PR DESCRIPTION
## Summary

Add a post-push verification step for Docker images built by the matrix job. After `customImage.push()`, the pipeline now retries `docker manifest inspect` for the pushed image and fails the image setup stage if the tag is not visible in the registry.

## Root cause

A Jenkins image setup stage can report a successful `docker push` while the expected tag is still missing or not readable from Harbor. Downstream Kubernetes pods then fail later with `ErrImagePull`, which hides the actual publishing problem.

## Impact

This makes the failure happen immediately in the Docker image setup path and points at the missing registry artifact directly.

## Validation

- `git diff --check`
- `groovy -cp /private/tmp/groovy-stubs -e "new GroovyShell(this.class.classLoader).parse(new File('src/com/mellanox/cicd/Matrix.groovy')); println 'parse ok'"`
