### PR TITLE
Verify pushed Docker images

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1186,7 +1186,27 @@ def buildImage(img, filename, extra_args, config, image) {
         run_shell(preBuild, "Image preparation script")
     }
     customImage = docker.build("${img}", "-f ${filename} ${extra_args} . ")
-    customImage.push()
+    pushAndVerify(customImage, img, config)
+}
+
+def pushAndVerify(customImage, String img, config) {
+    def attempts = 6
+    def delaySeconds = 10
+
+    for (int i=1; i<=attempts; i++) {
+        customImage.push()
+        if (imageExistsInRegistry(img, config)) {
+            config.logger.info("Verified pushed image in registry - ${img}")
+            return
+        }
+
+        if (i < attempts) {
+            config.logger.warn("Pushed image is not visible in registry yet - ${img} - retry ${i}/${attempts}")
+            sleep(time: delaySeconds, unit: 'SECONDS')
+        }
+    }
+
+    reportFail('docker push', "Pushed image ${img} is not visible in registry after ${attempts} attempts")
 }
 
 Boolean isEnvVarSet(var) {

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1192,30 +1192,30 @@ def buildImage(img, filename, extra_args, config, image) {
 def pushAndVerify(customImage, String img, config) {
     def attempts = 3
     def delaySeconds = 10
+    def lastPushError = null
 
     for (int i=1; i<=attempts; i++) {
-        def pushed = false
         try {
             customImage.push()
-            pushed = true
+            lastPushError = null
         } catch (Exception e) {
+            lastPushError = e
             config.logger.warn("docker push failed - ${img} - attempt ${i}/${attempts}: ${e.message}")
         }
 
-        if (pushed && imageExistsInRegistry(img, config)) {
+        if (imageExistsInRegistry(img, config)) {
             config.logger.info("Verified pushed image in registry - ${img}")
             return
         }
 
         if (i < attempts) {
-            if (pushed) {
-                config.logger.warn("Pushed image is not visible in registry yet - ${img} - retry ${i}/${attempts}")
-            }
+            config.logger.warn("Pushed image is not visible in registry yet - ${img} - retry ${i}/${attempts}")
             sleep(time: delaySeconds, unit: 'SECONDS')
         }
     }
 
-    reportFail('docker push', "Pushed image ${img} is not visible in registry after ${attempts} attempts")
+    def suffix = lastPushError ? " Last push error: ${lastPushError.message}" : ""
+    reportFail('docker push', "Pushed image ${img} is not visible in registry after ${attempts} attempts.${suffix}")
 }
 
 Boolean isEnvVarSet(var) {

--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1190,18 +1190,27 @@ def buildImage(img, filename, extra_args, config, image) {
 }
 
 def pushAndVerify(customImage, String img, config) {
-    def attempts = 6
+    def attempts = 3
     def delaySeconds = 10
 
     for (int i=1; i<=attempts; i++) {
-        customImage.push()
-        if (imageExistsInRegistry(img, config)) {
+        def pushed = false
+        try {
+            customImage.push()
+            pushed = true
+        } catch (Exception e) {
+            config.logger.warn("docker push failed - ${img} - attempt ${i}/${attempts}: ${e.message}")
+        }
+
+        if (pushed && imageExistsInRegistry(img, config)) {
             config.logger.info("Verified pushed image in registry - ${img}")
             return
         }
 
         if (i < attempts) {
-            config.logger.warn("Pushed image is not visible in registry yet - ${img} - retry ${i}/${attempts}")
+            if (pushed) {
+                config.logger.warn("Pushed image is not visible in registry yet - ${img} - retry ${i}/${attempts}")
+            }
             sleep(time: delaySeconds, unit: 'SECONDS')
         }
     }


### PR DESCRIPTION
## Summary

Add a post-push verification step for Docker images built by the matrix job. After `customImage.push()`, the pipeline now retries `docker manifest inspect` for the pushed image and fails the image setup stage if the tag is not visible in the registry.

## Root cause

A Jenkins image setup stage can report a successful `docker push` while the expected tag is still missing or not readable from Harbor. Downstream Kubernetes pods then fail later with `ErrImagePull`, which hides the actual publishing problem.

## Impact

This makes the failure happen immediately in the Docker image setup path and points at the missing registry artifact directly.

## Validation

- `git diff --check`
- `groovy -cp /private/tmp/groovy-stubs -e "new GroovyShell(this.class.classLoader).parse(new File('src/com/mellanox/cicd/Matrix.groovy')); println 'parse ok'"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image publishing: pushes now verify registry visibility and automatically retry (up to 3 attempts with short delays) when images aren’t immediately visible, reducing false build failures.
  * If the image still fails to appear after retries, the pipeline now fails early with a clear error to surface real publish issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/ci-demo/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->