### PR TITLE
Add 3 attempts to push docker image

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -1193,8 +1193,22 @@ def buildImage(img, filename, extra_args, config, image) {
     if (preBuild) {
         run_shell(preBuild, "Image preparation script")
     }
-    customImage = docker.build("${img}", "-f ${filename} ${extra_args} . ")
-    customImage.push()
+
+    def customImage = docker.build("${img}", "-f ${filename} ${extra_args} . ")
+    def maxAttempts = 3
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            customImage.push()
+            break
+        } catch (Exception e) {
+            if (attempt < maxAttempts) {
+                config.logger.warn("Docker push attempt ${attempt}/${maxAttempts} failed for ${img}: ${e.message}. Retrying...")
+                sleep(time: 10, unit: 'SECONDS')
+            } else {
+                reportFail('docker push', "Failed to push '${img}' after ${maxAttempts} attempts. Last error: ${e.message}")
+            }
+        }
+    }
 }
 
 Boolean isEnvVarSet(var) {


### PR DESCRIPTION
Docker push fail due to Harbor issues. Add 3-attempt
retry loop and a 10-second delay between attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image build reliability: build attempts are automatically retried up to 3 times with short delays and attempt logging; persistent failures are reported to reduce disruptions from transient build errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/ci-demo/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->