### PR TITLE
fix(matrix): honor timeout on module-type steps

### DIFF
--- a/src/com/mellanox/cicd/Matrix.groovy
+++ b/src/com/mellanox/cicd/Matrix.groovy
@@ -615,7 +615,15 @@ def run_step(image, config, title, oneStep, axis, runtime=null) {
             }
 
             config.logger.trace(4, "Running step action module=" + oneStep.module + " args=" + oneStep.args + " run=" + oneStep.run)
-            int rc = this."${oneStep.module}"(this, oneStep, config)
+            def timeout_minutes = getConfigVal(config, ['timeout'], null, true, oneStep, true)
+            def rc
+            if (timeout_minutes) {
+                timeout(time: timeout_minutes, unit: 'MINUTES') {
+                    rc = this."${oneStep.module}"(this, oneStep, config)
+                }
+            } else {
+                rc = this."${oneStep.module}"(this, oneStep, config)
+            }
             if (rc != 0) {
                 reportFail(oneStep.name, "exit with error code=${rc}")
             }


### PR DESCRIPTION
Per-step `timeout` was silently ignored for steps using `module: <name>` (e.g. `module: slurm`). The action branch of `run_step` dispatches modules directly, bypassing `run_step_shell` — the only path that reads `timeout` and wraps execution in Jenkins' `timeout()`.

Apply the fix centrally so all module types (`slurm`, `dynamicAction`, ...) honor `timeout` uniformly: the action branch now reads the same `getConfigVal(..., ['timeout'], ...)` value used by shell steps and wraps the module dispatch in `timeout(time: X, unit: 'MINUTES')`.

`onfail`/`always` plumbing still does not exist for module steps, so on timeout the `FlowInterruptedException` propagates and aborts the stage. That can be added in a follow-up if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional timeout configuration for pipeline steps. Users can now specify timeout durations to automatically terminate steps that exceed configured limits, improving pipeline reliability and preventing hung executions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mellanox/ci-demo/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->